### PR TITLE
xml.dict_to_xml() to save Mitsuba XML scene from Python

### DIFF
--- a/include/mitsuba/python/docstr.h
+++ b/include/mitsuba/python/docstr.h
@@ -3853,16 +3853,6 @@ static const char *__doc_mitsuba_PluginManager_PluginManagerPrivate = R"doc()doc
 static const char *__doc_mitsuba_PluginManager_class = R"doc()doc";
 
 static const char *__doc_mitsuba_PluginManager_create_object =
-R"doc(Instantiate a plugin and return the newly created object instance.
-
-Parameter ``props``:
-    A Properties instance containing all information required to find
-    and construct the plugin.
-
-Parameter ``variant``:
-    Expected variant of the instance.)doc";
-
-static const char *__doc_mitsuba_PluginManager_create_object_2 =
 R"doc(Instantiate a plugin, verify its type, and return the newly created
 object instance.
 
@@ -3874,17 +3864,19 @@ Parameter ``class_type``:
     Expected type of the instance. An exception will be thrown if it
     turns out not to derive from this class.)doc";
 
-static const char *__doc_mitsuba_PluginManager_create_object_3 = R"doc(Convenience template wrapper around create_object())doc";
+static const char *__doc_mitsuba_PluginManager_create_object_2 = R"doc(Convenience template wrapper around create_object())doc";
 
 static const char *__doc_mitsuba_PluginManager_d = R"doc()doc";
 
 static const char *__doc_mitsuba_PluginManager_ensure_plugin_loaded = R"doc(Ensure that a plugin is loaded and ready)doc";
 
+static const char *__doc_mitsuba_PluginManager_get_plugin_class = R"doc(Return the class corresponding to a plugin for a specific variant)doc";
+
 static const char *__doc_mitsuba_PluginManager_instance = R"doc(Return the global plugin manager)doc";
 
 static const char *__doc_mitsuba_PluginManager_loaded_plugins = R"doc(Return the list of loaded plugins)doc";
 
-static const char *__doc_mitsuba_PluginManager_register_python_plugin = R"doc()doc";
+static const char *__doc_mitsuba_PluginManager_register_python_plugin = R"doc(Register a Python plugin)doc";
 
 static const char *__doc_mitsuba_Point = R"doc()doc";
 

--- a/src/libcore/python/object.cpp
+++ b/src/libcore/python/object.cpp
@@ -1,5 +1,6 @@
 #include <mitsuba/python/python.h>
 #include <mitsuba/core/logger.h>
+#include <mitsuba/core/plugin.h>
 
 extern py::object cast_object(Object *o);
 
@@ -30,7 +31,15 @@ public:
 };
 
 MTS_PY_EXPORT(Object) {
-    py::class_<Class>(m, "Class", D(Class));
+    py::class_<Class, std::unique_ptr<Class, py::nodelete>>(m, "Class", D(Class))
+        .def_method(Class, name)
+        .def_method(Class, variant)
+        .def_method(Class, alias)
+        .def_method(Class, parent);
+
+    py::class_<PluginManager, std::unique_ptr<PluginManager, py::nodelete>>(m, "PluginManager", D(PluginManager))
+        .def_static_method(PluginManager, instance, py::return_value_policy::reference)
+        .def_method(PluginManager, get_plugin_class, "name"_a, "variant"_a);
 
     py::class_<TraversalCallback, PyTraversalCallback>(m, "TraversalCallback")
         .def(py::init<>());


### PR DESCRIPTION
This PR includes the following:
- Minimal bindings of `Class` and `PluginManager` needed on the Python side
- Add support for `references` in the `dict` representation of Mistuba objects/scene
- Update `xml.load_dict()` accordingly
- `xml.dict_to_xml()` function to save XML file give a valid Python `dict`

This PR is related to the WIP Blender add-on, which will provide functionality for constructing a Python `dict` compatible with the above functions. 

## TODOs

- [ ] Add support for `ref` in `xml.load_dict()`
- [ ] ...